### PR TITLE
Fix a bug of operator precedence in LP selection

### DIFF
--- a/Fitter/partiallyMerged/README.md
+++ b/Fitter/partiallyMerged/README.md
@@ -44,11 +44,26 @@ Commands used for current fitting:
 ```
 python runSF_nanoAOD.py -b --doBinned --tagger SelectedJet_tau21 --workspace workspace_tau21_0p35_0p75 --HP 0.35 --LP 0.75 --doWS &
 python runSF_nanoAOD.py -b --doBinned --tagger SelectedJet_tau21 --workspace workspace_tau21_0p35_0p75_topPt --HP 0.35 --LP 0.75 --topPt --doWS &
+python runSF_nanoAOD.py -b --doBinned --tagger SelectedJet_tau21 --workspace workspace_tau21_0p35_0p75_topGen --HP 0.35 --LP 0.75 --topGen --doWS &
 python runSF_nanoAOD.py -b --doBinned --tagger SelectedJet_tau21 --workspace workspace_tau21_0p35_0p75_topShower --HP 0.35 --LP 0.75 --topShower --doWS &
+
+python runSF_nanoAOD.py -b --doBinned --tagger SelectedJet_tau21 --workspace workspace_tau21_0p45_0p75 --HP 0.45 --LP 0.75 --doWS &
+python runSF_nanoAOD.py -b --doBinned --tagger SelectedJet_tau21 --workspace workspace_tau21_0p45_0p75_topPt --HP 0.45 --LP 0.75 --topPt --doWS &
+python runSF_nanoAOD.py -b --doBinned --tagger SelectedJet_tau21 --workspace workspace_tau21_0p45_0p75_topGen --HP 0.45 --LP 0.75 --topGen --doWS &
+python runSF_nanoAOD.py -b --doBinned --tagger SelectedJet_tau21 --workspace workspace_tau21_0p45_0p75_topShower --HP 0.45 --LP 0.75 --topShower --doWS &
+
 
 python runSF_nanoAOD.py -b --doBinned --tagger SelectedJet_tau21_ddt_retune --workspace workspace_tau21ddt_0p43_0p79 --HP 0.43 --LP 0.79 --doWS &
 python runSF_nanoAOD.py -b --doBinned --tagger SelectedJet_tau21_ddt_retune --workspace workspace_tau21ddt_0p43_0p79_topPt --HP 0.43 --LP 0.79 --topPt --doWS &
+python runSF_nanoAOD.py -b --doBinned --tagger SelectedJet_tau21_ddt_retune --workspace workspace_tau21ddt_0p43_0p79_topGen --HP 0.43 --LP 0.79 --topGen --doWS &
 python runSF_nanoAOD.py -b --doBinned --tagger SelectedJet_tau21_ddt_retune --workspace workspace_tau21ddt_0p43_0p79_topShower --HP 0.43 --LP 0.79 --topShower --doWS &
+
+python runSF_nanoAOD.py -b --doBinned --tagger SelectedJet_tau21_ddt_retune --workspace workspace_tau21ddt_0p43_0p82 --HP 0.43 --LP 0.82 --doWS &
+
+python runSF_nanoAOD.py -b --doBinned --tagger SelectedJet_tau21_ddt_retune --workspace workspace_tau21ddt_0p50_0p80 --HP 0.50 --LP 0.80 --doWS &
+python runSF_nanoAOD.py -b --doBinned --tagger SelectedJet_tau21_ddt_retune --workspace workspace_tau21ddt_0p50_0p80_topPt --HP 0.50 --LP 0.80 --topPt --doWS &
+python runSF_nanoAOD.py -b --doBinned --tagger SelectedJet_tau21_ddt_retune --workspace workspace_tau21ddt_0p50_0p80_topGen --HP 0.50 --LP 0.80 --topGen --doWS &
+python runSF_nanoAOD.py -b --doBinned --tagger SelectedJet_tau21_ddt_retune --workspace workspace_tau21ddt_0p50_0p80_topShower --HP 0.50 --LP 0.80 --topShower --doWS &
 ```
 
 

--- a/Fitter/partiallyMerged/runSF_nanoAOD.py
+++ b/Fitter/partiallyMerged/runSF_nanoAOD.py
@@ -1091,8 +1091,7 @@ class initialiseFits:
              combData_p_f.add(RooArgSet(rrv_mass_j,category_p_f),tmp_event_weight)
           
           # TOTAL category (no Tau21 )
-          if discriminantCut == 2 or discriminantCut == 1 or discriminantCut == 0 and (rrv_mass_j.getMin() < tmp_jet_mass < rrv_mass_j.getMax()):   
-
+          if (discriminantCut == 2 or discriminantCut == 1 or discriminantCut == 0) and (rrv_mass_j.getMin() < tmp_jet_mass < rrv_mass_j.getMax())
               rrv_mass_j.setVal(tmp_jet_mass)
 
               if tmp_jet_mass >= self.mj_signal_min and tmp_jet_mass <self.mj_signal_max :

--- a/Fitter/python/fitutils.py
+++ b/Fitter/python/fitutils.py
@@ -65,6 +65,30 @@ def getLegend(mplot,channel,x1=0.62,x2=0.7,y1=0.92,y2=0.9):
     theLeg.SetTextFont(42)
 
     return theLeg       
+
+
+def pdfDSCBtoGAUS(ws, sample):
+    rrv_alpha1 = ws.var("rrv_alpha1_ttbar_"+sample+"_em_mj")
+    rrv_alpha2 = ws.var("rrv_alpha2_ttbar_"+sample+"_em_mj")
+#    rrv_sign1 = ws.var("rrv_sign1_ttbar_"+sample+"_em_mj")
+#    rrv_sign2 = ws.var("rrv_sign2_ttbar_"+sample+"_em_mj")
+    
+    if not rrv_alpha1==None:
+        rrv_alpha1.setVal(4.5); rrv_alpha1.setMin(4.); rrv_alpha1.setMax(5.)
+    if not rrv_alpha2==None:
+        rrv_alpha2.setVal(4.5); rrv_alpha2.setMin(4.); rrv_alpha2.setMax(5.)
+
+def pdfGAUStoDSCB(ws, sample):
+    rrv_alpha1 = ws.var("rrv_alpha1_ttbar_"+sample+"_em_mj")
+    rrv_alpha2 = ws.var("rrv_alpha2_ttbar_"+sample+"_em_mj")
+#    rrv_sign1 = ws.var("rrv_sign1_ttbar_"+sample+"_em_mj")
+#    rrv_sign2 = ws.var("rrv_sign2_ttbar_"+sample+"_em_mj")
+    
+    if not rrv_alpha1==None:
+        rrv_alpha1.setVal(1.); rrv_alpha1.setMin(0.1); rrv_alpha1.setMax(5.)
+    if not rrv_alpha2==None:
+        rrv_alpha2.setVal(1.); rrv_alpha2.setMin(0.1); rrv_alpha2.setMax(5.)
+
     
 def doTTscalefactor(workspace,channel):
 
@@ -152,15 +176,16 @@ def fit_mj_single_MC(workspace,fileName,label, model,channel, wtagger_label,wsna
     cs = getPavetext()
     cs.AppendPad("same")
     mplot.addObject(cs)
-    try: os.stat("plots/MCfits/") 
-    except: os.makedirs("plots/MCfits/")
     c1 = getCanvas()
     mplot.Draw()
     # leg1.Draw("same")
     # from time import sleep
     # sleep(100)
-    c1.SaveAs("plots/MCfits/"+label+"_"+wsname+".png")
-    c1.SaveAs("plots/MCfits/"+label+"_"+wsname+".pdf")
+    dirname = "plots/"+wsname.replace('workspace_', '')
+    if not os.path.exists(dirname): os.makedirs(dirname)
+    if not os.path.exists(dirname+"/MCfits"): os.makedirs(dirname+"/MCfits")
+    c1.SaveAs(dirname+"/MCfits/"+label.replace('_', '', 1)+".png")
+    c1.SaveAs(dirname+"/MCfits/"+label.replace('_', '', 1)+".pdf")
 
     # TODO # draw_canvas_with_pull(mplot,mplot_pull,rt.RooArgList(*parameters_list),"plots/MCfits/",label+fileName,model,channel,0,0,GetLumi())
     workspace.var("rrv_number"+label+"_"+channel+"_mj").setVal(workspace.var("rrv_number"+label+"_"+channel+"_mj").getVal()*workspace.var("rrv_scale_to_lumi"+label+"_"+channel).getVal())
@@ -502,7 +527,7 @@ def DrawScaleFactorTTbarControlSample(xtitle,workspace, color_palet, label, chan
         xframe_data_fail.GetYaxis().SetRangeUser(1e-2,xframe_data_fail.GetMaximum()*1.5);
         
         legend = getLegend(xframe_data,"em",0.3885213,0.6640827,0.9774937,0.8992248)
-        legend.AddEntry(xframe_data.findObject("data")       ,"CMS data"            ,"PLE"); 
+        legend.AddEntry(xframe_data.findObject("data")       ,"Data"                ,"PLE"); 
         legend.AddEntry(xframe_data.findObject("TTbar_fakeW"),"t#bar{t} (unmerged)" ,"F");
         legend.AddEntry(xframe_data.findObject("Data fit")   ,"Data fit"            ,"L");
         legend.AddEntry(xframe_data.findObject("STop")       ,"Single top"          ,"F");
@@ -520,19 +545,19 @@ def DrawScaleFactorTTbarControlSample(xtitle,workspace, color_palet, label, chan
         xframe_data.Draw()
         CMS_lumi(c1, iPeriod, iPos)
         c1.Update()
-        outname = "plots/%s_"%outname
-        c1.SaveAs(outname+"pass.png")
-        c1.SaveAs(outname+"pass.pdf")
-        c1.SaveAs(outname+"pass.C")
-        c1.SaveAs(outname+"pass.root")
+        dirname = "plots/"+outname.replace('workspace_', '')
+        c1.SaveAs(dirname+"/pass.png")
+        c1.SaveAs(dirname+"/pass.pdf")
+        c1.SaveAs(dirname+"/pass.C")
+        c1.SaveAs(dirname+"/pass.root")
         c1.cd()
         xframe_data_fail.Draw()
         CMS_lumi(c1, iPeriod, iPos)
         c1.Update()
-        c1.SaveAs(outname+"fail.png")
-        c1.SaveAs(outname+"fail.pdf")
-        c1.SaveAs(outname+"fail.C")
-        c1.SaveAs(outname+"fail.root")
+        c1.SaveAs(dirname+"/fail.png")
+        c1.SaveAs(dirname+"/fail.pdf")
+        c1.SaveAs(dirname+"/fail.C")
+        c1.SaveAs(dirname+"/fail.root")
         
         
                 # # #signal window

--- a/Fitter/python/makepdf.py
+++ b/Fitter/python/makepdf.py
@@ -455,25 +455,30 @@ def MakeGeneralPdf(workspace,label,model,spectrum,wtagger_label, channel,constra
     if model.find("DoubleSidedCB")!=-1:
         isfinal = ("_TotalMC" in label or "_data" in label)
         freelabel, corrlabel = label, label.replace("_failtau2tau1cut", "")
-        rrv_mean1_gaus   = RooRealVar("rrv_mean1_gaus"+(corrlabel if not 'ddt' in wsname else freelabel)+"_"+channel+spectrum,"rrv_mean1_gaus"+label+"_"+channel+spectrum, 89., 80., 100.) # 89., 75., 100.
-        rrv_sigma1_gaus  = RooRealVar("rrv_sigma1_gaus"+(corrlabel if not 'ddt' in wsname else corrlabel)+"_"+channel+spectrum,"rrv_sigma1_gaus"+label+"_"+channel+spectrum, 8., 5., 20.) # 9., 1., 20.
+        rrv_mean1_gaus   = RooRealVar("rrv_mean1_gaus"+freelabel+"_"+channel+spectrum,"rrv_mean1_gaus"+label+"_"+channel+spectrum, 89., 80., 100.) # 89., 75., 100.
+        rrv_sigma1_gaus  = RooRealVar("rrv_sigma1_gaus"+freelabel+"_"+channel+spectrum,"rrv_sigma1_gaus"+label+"_"+channel+spectrum, 8., 5., 20.) # 9., 1., 20.
         rrv_alpha1  = RooRealVar("rrv_alpha1"+corrlabel+"_"  +channel+spectrum, "rrv_alpha1"+label+"_"  +channel+spectrum, 0.5, 0.1, 10.) # 0.5, 0.1, 10.
         rrv_alpha2  = RooRealVar("rrv_alpha2"+corrlabel+"_"  +channel+spectrum, "rrv_alpha2"+label+"_"  +channel+spectrum, 1.0, 0.1, 10.) # 1., 0.1, 10.
         rrv_sign1   = RooRealVar("rrv_sign1" +corrlabel+"_"  +channel+spectrum, "rrv_sign1" +label+"_"  +channel+spectrum, 0.2, 0.01, 5.) # 2, 1, 5.
         rrv_sign2   = RooRealVar("rrv_sign2" +corrlabel+"_"  +channel+spectrum, "rrv_sign2" +label+"_"  +channel+spectrum, 0.2, 0.01, 10.) # 2, 1, 10.
+        
         # small sign values mean high tails. 1 is left, 2 is right.
         if isfinal:
-            rrv_sign1.setMin(0.1); rrv_sign2.setMin(0.1);
-            if 'ddt' in wsname:
-                rrv_alpha1.setVal(2.8); rrv_alpha1.setMin(2.5); rrv_alpha2.setVal(2.8); rrv_alpha2.setMin(0.5);
+            if not 'ddt' in wsname:
+                rrv_mean1_gaus.SetName("rrv_mean1_gaus"+corrlabel+"_"+channel+spectrum)
+                rrv_sigma1_gaus.SetName("rrv_sigma1_gaus"+corrlabel+"_"+channel+spectrum)
                 if 'topShower' in wsname:
-                    rrv_alpha1.setVal(4.); rrv_alpha1.setMin(3.); rrv_alpha2.setVal(4.); rrv_alpha2.setMin(3.);
-            else:
-                if 'topShower' in wsname:
+                    rrv_alpha1.setMax(1.); rrv_alpha2.setMax(1.);
+                    rrv_mean1_gaus.SetName("rrv_mean1_gaus"+freelabel+"_"+channel+spectrum)
                     rrv_sigma1_gaus.SetName("rrv_sigma1_gaus"+freelabel+"_"+channel+spectrum)
-                    rrv_alpha1.setVal(3.); rrv_alpha1.setMin(2.5); rrv_alpha2.setVal(3.); rrv_alpha2.setMin(2.5);
+            if 'ddt_0p50_0p80' in wsname:
+                rrv_mean1_gaus.SetName("rrv_mean1_gaus"+corrlabel+"_"+channel+spectrum)
+                rrv_sigma1_gaus.SetName("rrv_sigma1_gaus"+corrlabel+"_"+channel+spectrum)
+            if 'ddt_0p43_0p79' in wsname and 'topGen' in wsname:
+                rrv_alpha1.setVal(5.); rrv_alpha2.setVal(5.); rrv_alpha1.setMin(4.5); rrv_alpha2.setMin(4.5); rrv_sign1.setMin(0.2); rrv_sign2.setMin(0.2);
+            if 'ddt_0p50_0p80' in wsname and 'topShower' in wsname:
+                rrv_alpha1.setVal(5.); rrv_alpha2.setVal(5.); rrv_alpha1.setMin(4.5); rrv_alpha2.setMin(4.5);
         model_pdf   = ROOT.RooDoubleCrystalBall("model_pdf"+label+"_"+channel+spectrum,"model_pdf"+label+"_"+channel+spectrum, rrv_x, rrv_mean1_gaus, rrv_sigma1_gaus, rrv_alpha1, rrv_sign1, rrv_alpha2, rrv_sign2)
-#        model_pdf   = ROOT.RooCBShape("model_pdf"+label+"_"+channel+spectrum,"model_pdf"+label+"_"+channel+spectrum, rrv_x, rrv_mean1_gaus, rrv_sigma1_gaus, rrv_alpha1, rrv_sign1); tmp=rrv_alpha1.getMax();rrv_alpha1.setMax(-rrv_alpha1.getMin());rrv_alpha1.setMin(-tmp);rrv_alpha1.setVal(-rrv_alpha1.getVal())
         if 'bias' in wsname:
             model_pdf   = RooGaussian("model_pdf"+label+"_"+channel+spectrum,"model_pdf"+label+"_"+channel+spectrum, rrv_x, rrv_mean1_gaus, rrv_sigma1_gaus)
     

--- a/Skimmer/do-control-plots.py
+++ b/Skimmer/do-control-plots.py
@@ -26,7 +26,7 @@ iPeriod = 4 #iPeriod = 0 for simulation-only plots
 #cut = "(1==1)"
 #cut = "(passedMETfilters&&abs(dr_LepJet)>1.5708&&abs(dphi_MetJet)>1.5708&&Muon_highPtId[0]>=2&&Muon_isPFcand[0]&&Muon_pfIsoId[0]>=6&&W_pt>150.&&maxAK4CSV<0.8484)"
 cut = "(maxAK4CSV>0.8484&&Wlep_type==0)" # && SelectedJet_softDrop_mass > 50. && SelectedJet_softDrop_mass < 130. && SelectedJet_pt > 200. && SelectedJet_pt < 10000.)"
-vars = ["SelectedJet_softDrop_mass","SelectedJet_tau21", "SelectedJet_tau21_ddt", "SelectedJet_tau21_ddt_retune","FatJet_pt[0]","FatJet_eta[0]","FatJet_phi[0]","FatJet_tau1[0]","FatJet_tau2[0]","FatJet_tau3[0]","FatJet_mass[0]","FatJet_msoftdrop[0]","SelectedLepton_pt","SelectedLepton_iso","maxAK4CSV","nFatJet", "nJet", "nMuon","PV_npvs","W_pt","MET_pt","fabs(dphi_WJet)","fabs(dphi_MetJet)","fabs(dphi_LepJet)","dr_LepJet"]
+vars = ["SelectedJet_softDrop_mass","SelectedJet_tau21", "SelectedJet_tau21_ddt", "SelectedJet_tau21_ddt_retune", "FatJet_pt[0]","FatJet_eta[0]","FatJet_phi[0]","FatJet_tau1[0]","FatJet_tau2[0]","FatJet_tau3[0]","FatJet_mass[0]","FatJet_msoftdrop[0]","SelectedLepton_pt","SelectedLepton_iso","maxAK4CSV","nFatJet", "nJet", "nMuon","PV_npvs","W_pt","MET_pt","fabs(dphi_WJet)","fabs(dphi_MetJet)","fabs(dphi_LepJet)","dr_LepJet"]
 #vars = ["SelectedJet_tau21", "FatJet_pt[0]", "W_pt", "SelectedJet_softDrop_mass","SelectedJet_tau21", "SelectedJet_tau21_ddt", "SelectedJet_tau21_ddt_retune"] 
 #vars += [ "Muon_pt[0]", "Muon_pfRelIso03_all[0]" ]
 #vars += ["Electron_eta[0]", "Electron_phi[0]", "Electron_pt[0]", "Electron_pfRelIso03_all[0]"]
@@ -52,17 +52,15 @@ bkgs.append(VVs)
 bkgs.append(WJs)
 bkgs.append(TTs)
 
-dir = "/scratch/zucchett/Ntuple/WSF/v5/" #"/work/mhuwiler/data/WScaleFactors/added/"
-outdirname = ""
+dir = "/scratch/zucchett/Ntuple/WSF/" #"/work/mhuwiler/data/WScaleFactors/added/"
 
-plotdirname = "plots/"+outdirname+"/plots/"
-plotdirnameWCR = "plots/"+outdirname+"/plotsWCR/"
-if not os.path.isdir(plotdirname) : os.system('mkdir -p '+plotdirname)
-if not os.path.isdir(plotdirnameWCR) : os.system('mkdir -p '+plotdirnameWCR)
-plotdir = plotdirname if "maxAK4CSV>" in cut else plotdirnameWCR #"plots/" if "maxAK4CSV>" in cut else "plotsWCR/"
+plotdir = "plots/"
+if "maxAK4CSV<" in cut: plotdir = "plots/WCR/"
+if 'herwig' in TTs[0]: plotdir = "plots/Herwig/"
+if not os.path.isdir(plotdir) : os.system('mkdir -p '+plotdir)
 
 #For drawing
-legs=["QCD", "Single Top","VV","W+jets", "TT"]
+legs=["QCD", "Single Top","VV","W+jets", "TT" if not 'herwig' in TTs[0] else 'TT Herwig']
 fillcolor = [921,432,600,632,417]
 
 

--- a/Skimmer/doSkim.py
+++ b/Skimmer/doSkim.py
@@ -9,9 +9,10 @@ else:
 #      "root://cms-xrd-global.cern.ch//store/data/Run2018D/SingleMuon/NANOAOD/Nano14Dec2018_ver2-v1/40000/4BF53ABE-BB2D-B147-8BDE-888B21C3E07C.root"
 #      "root://cms-xrd-global.cern.ch//store/mc/RunIIAutumn18NanoAODv4/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/NANOAODSIM/Nano14Dec2018_102X_upgrade2018_realistic_v16-v1/120000/BB978C6D-1770-CB42-A45E-AFAA249DAA82.root"
 #      "root://cms-xrd-global.cern.ch//store/mc/RunIIAutumn18NanoAODv4/ZZ_TuneCP5_13TeV-pythia8/NANOAODSIM/Nano14Dec2018_102X_upgrade2018_realistic_v16-v1/110000/56817FDC-2D4C-7E4B-ABA0-9A1F7BA505C4.root"
-#      "root://cms-xrd-global.cern.ch//store/data/Run2018C/EGamma/NANOAOD/Nano1June2019-v1/230000/77B1D6B0-11DB-7D4C-83D5-5CDD162BFE61.root"
+      "root://cms-xrd-global.cern.ch//store/data/Run2018C/EGamma/NANOAOD/Nano1June2019-v1/230000/77B1D6B0-11DB-7D4C-83D5-5CDD162BFE61.root"
+#      "root://cms-xrd-global.cern.ch//store/data/Run2018D/SingleMuon/NANOAOD/Nano1June2019-v1/40000/CB01BD35-453E-254D-A273-A867E34D7E52.root"
 #      "root://cms-xrd-global.cern.ch//store/mc/RunIIAutumn18NanoAODv5/ST_t-channel_top_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/NANOAODSIM/Nano1June2019_102X_upgrade2018_realistic_v19-v1/110000/DDC35B8C-5718-4F41-8499-EDE8E3283FF5.root"
-      "root://cms-xrd-global.cern.ch//store/mc/RunIIAutumn18NanoAODv5/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/NANOAODSIM/Nano1June2019_102X_upgrade2018_realistic_v19-v1/120000/D23F4374-1259-174E-B968-E914679919BD.root"
+#      "root://cms-xrd-global.cern.ch//store/mc/RunIIAutumn18NanoAODv5/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/NANOAODSIM/Nano1June2019_102X_upgrade2018_realistic_v19-v1/120000/D23F4374-1259-174E-B968-E914679919BD.root"
   ]
 
 if len(sys.argv)>2: outputDir = sys.argv[2]
@@ -24,24 +25,24 @@ if len(sys.argv)>4: chunck = sys.argv[4]
 else: chunck = ""  
 
 #"keep_and_drop.txt"
-#FatJet_msoftdrop>30&&MET_sumEt>40&&    ((nElectron>0&&HLT_Ele115_CaloIdVT_GsfTrkIdT)||
+
 if infile[0].find("SingleMuon")!=-1:
   channel = "mu"
   print "Processing a Single Muon dataset file..."
-  p=PostProcessor(outputDir, infile, None, None,
+  p=PostProcessor(outputDir, infile, "HLT_Mu50 && nMuon>0 && Muon_pt[0]>55. && nFatJet>0", None,
                     modules=[Skimmer(channel)],provenance=False,fwkJobReport=False,
                     jsonInput='/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/PromptReco/Cert_314472-325175_13TeV_PromptReco_Collisions18_JSON.txt')
                    
-elif infile[0].find("SingleElectron")!=-1:
+elif infile[0].find("EGamma")!=-1:
   channel = "el"
   print "Processing a Single Electron dataset file..."
-  p=PostProcessor(outputDir, infile, None, None,
+  p=PostProcessor(outputDir, infile, "(event.HLT_Ele32_WPTight_Gsf || event.HLT_Ele35_WPTight_Gsf || event.HLT_Ele40_WPTight_Gsf || HLT_Ele115_CaloIdVT_GsfTrkIdT) && nElectron>0 && Electron_pt[0]>55. && nFatJet>0", None,
                     modules=[Skimmer(channel)],provenance=False,fwkJobReport=False,
                     jsonInput='/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/PromptReco/Cert_314472-325175_13TeV_PromptReco_Collisions18_JSON.txt')
                     
 else:
   print "Processing MC..."
-  channel = "mu"
+  channel = "elmu"
   p=PostProcessor(outputDir, infile, None, None,
                     modules=[Skimmer(channel)],provenance=False,fwkJobReport=False)
 p.run()

--- a/Skimmer/qsub/addWeight.py
+++ b/Skimmer/qsub/addWeight.py
@@ -91,7 +91,7 @@ def processFile(sample_name, verbose=False):
         
         # Weights
         if isMC:
-            eventweightlumi[0] = Leq * tree.lheweight * tree.btagweight #tree.puweight
+            eventweightlumi[0] = Leq * tree.lheweight * tree.btagweight * tree.triggerweight #tree.puweight
         else:
             eventweightlumi[0] = 1.
             

--- a/Skimmer/qsub/qsub_script_SFs.py
+++ b/Skimmer/qsub/qsub_script_SFs.py
@@ -28,21 +28,22 @@ else:
 if infile[0].find("SingleMuon")!=-1:
   channel = "mu"
   print "Processing a Single Muon dataset file..."
-  p=PostProcessor(outputDir, infile, None, None,
+  p=PostProcessor(outputDir, infile, None, None, #"HLT_Mu50 && nMuon>0 && Muon_pt[0]>55. && nFatJet>0"
                     modules=[Skimmer(channel)],provenance=False,fwkJobReport=False,
                     jsonInput='/work/zucchett/WTagging/CMSSW_10_2_6/src/WTopScalefactorProducer/Skimmer/python/JSON/Cert_314472-325175_13TeV_PromptReco_Collisions18_JSON.txt',
                     )
-                   
-elif infile[0].find("SingleElectron")!=-1:
+
+elif infile[0].find("EGamma")!=-1:
   channel = "el"
   print "Processing a Single Electron dataset file..."
-  p=PostProcessor(outputDir, infile, None, None,
-                    modules=[Skimmer(channel)],provenance=False,fwkJobReport=False)
-                    # jsonInput='/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/PromptReco/Cert_294927-306462_13TeV_PromptReco_Collisions17_JSON.txt')
+  p=PostProcessor(outputDir, infile, None, None, #"(event.HLT_Ele32_WPTight_Gsf || event.HLT_Ele35_WPTight_Gsf || event.HLT_Ele40_WPTight_Gsf || HLT_Ele115_CaloIdVT_GsfTrkIdT) && nElectron>0 && Electron_pt[0]>55. && nFatJet>0"
+                    modules=[Skimmer(channel)],provenance=False,fwkJobReport=False,
+                    jsonInput='/work/zucchett/WTagging/CMSSW_10_2_6/src/WTopScalefactorProducer/Skimmer/python/JSON/Cert_314472-325175_13TeV_PromptReco_Collisions18_JSON.txt',
+                    )
 
 else:
   print "Processing MC..."
-  channel = "mu"
+  channel = "elmu"
   p=PostProcessor(outputDir, infile, None, None,
                     modules=[Skimmer(channel)],provenance=False,fwkJobReport=False)
 p.run()


### PR DESCRIPTION
Critical bug in LP selection during workspace creation. According to this: https://www.programiz.com/python-programming/precedence-associativity
the operator precedence in Python would make an odd selection for the LP category before this fix.
This is a critical bug, as it may affect the way the scale factors were obtained.